### PR TITLE
fix dumpConfig without credentials

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var tmp      = osenv.tmpdir()
 function dumpConfig (config) {
   var _config = JSON.parse(JSON.stringify(config))
   if (_config.credentials) _config.credentials.pass = _config.credentials.pass.replace(/./g,'*')
-  _config.Auth = _config.Auth.replace(/./g, '*')
+  if (_config.Auth) _config.Auth = _config.Auth.replace(/./g, '*')
   console.log(JSON.stringify(_config, null, 2))
 }
 


### PR DESCRIPTION
this will only happen if you try and run the program from the command-line and your config either does not exist or doesn't have credentials...

```
$ npmd-config 

/usr/local/lib/node_modules/npmd-config/index.js:16
  _config.credentials.pass = _config.credentials.pass.replace(/./g,'*')
                                                ^
TypeError: Cannot read property 'pass' of undefined
    at dumpConfig (/usr/local/lib/node_modules/npmd-config/index.js:16:49)
    at Object.<anonymous> (/usr/local/lib/node_modules/npmd-config/index.js:108:3)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```

cheers
