### PR TITLE
Ensure that tilde is an alias for $HOME

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,10 @@ var config = module.exports = (function () {
       .argv
   )
 
+  var homePattern = process.platform === 'win32' ? /^~(\/|\\)/ : /^~\//
+  if (config.prefix.match(homePattern) && home)
+    config.prefix = path.resolve(home, config.prefix.substr(2))
+
   config.bin = config.bin ||
   ( config.global ? path.join(config.prefix, 'bin')
   : path.join(config.path || process.cwd(), 'node_modules', '.bin'))


### PR DESCRIPTION
In my `.npmrc`, I have my `prefix` set to:

``` ini
prefix = ~/.npm-packages
```

`npm` recognizes that `~` should be replaced with `process.env.HOME`:

``` bash
$ npm config ls
; userconfig /home/kenan/.npmrc
prefix = "/home/kenan/.npm-packages"
```

But `npmd-config`, however, does not:

``` bash
$ npmd-config
{
  "prefix": "~/.npm-packages"
}
```

Which leads to this:

``` bash
$ npmd install -g browserify
{
  "name": "browserify",
  "version": "5.9.1",
  "shasum": "fb4eea5a2e8e855860389f99f4f832918f6e7640",
  "tarball": "http://registry.npmjs.org/browserify/-/browserify-5.9.1.tgz",
  "path": "/home/kenan/Code/temp/~/.npm-packages/lib/node_modules/browserify"
}
```

`npmd` globally installs to `CWD/~/.npm-packages` instead!

So I started searching through `npm` to see how this is solved over there, and I discovered [this logic in nopt](https://github.com/npm/nopt/blob/4296f7aba7847c198fea2da594f9e1bec02817ec/lib/nopt.js#L127-L138):

``` js
var homePattern = process.platform === 'win32' ? /^~(\/|\\)/ : /^~\//
if (val.match(homePattern) && process.env.HOME) {
  val = path.resolve(process.env.HOME, val.substr(2))
}
data[k] = path.resolve(String(val))
```

So this patch basically brings this logic to `npmd-config`. I can confirm that this fixes global installs for me, but frankly I do not know if there's anything else that should be tested.
